### PR TITLE
Aggiunge "script" al glossario

### DIFF
--- a/glossario.md
+++ b/glossario.md
@@ -11,6 +11,7 @@
  - Debug: Debug (Rimane invariato per motivi simili a quelli sopra)
  - Soft reload: Ricarica parziale
  - Breakpoint: Punto d'interruzione
+ - Script: Invariato (quando si ci riferisce a un file contenente delle istruzioni) o codice (quando ci si riferisce a solo alle istruzioni)
 
 ## Animazione
  - (Bezier) control point: Punto di controllo (di Bézier) NOTA: Nelle stringhe originali, "Bézier" è scritto senza accento. Questo è un errore da non riportare nella traduzione.


### PR DESCRIPTION
Come discusso su Discord, aggiunge script al glossario, con anche codice come traducente.